### PR TITLE
cassandra fix and upate

### DIFF
--- a/cassandra_cql.go
+++ b/cassandra_cql.go
@@ -346,6 +346,7 @@ func (f *cassandra_cql_ParserFactory) New() TCPProtocolInterpreter {
 }
 func init() {
 	factory := &cassandra_cql_ParserFactory{}
+	factory.parsed = make(map[uint16]string)
 	cassProt := &TCPProtocol{name: "cassandra_cql", defaultPort: 9042}
 	cassProt.interpFactory = factory
 	RegisterTCPProtocol(cassProt)


### PR DESCRIPTION
fix: factory.parsed was not initialized, resulting in hidden panics every time a prepared query was used.
update: emit aggregate execute metric as well as execute for specific query. otherwise, cassandra_protocol_observer`execute`latency is always blank/null for NAD's use of protocol_observer where the aggregate metric is force-enabled and the check is not managed by cgm where metrics are  automatically activated.